### PR TITLE
Allow mkdocs-pandoc to support structured pages

### DIFF
--- a/mkdocs_pandoc/pandoc_converter.py
+++ b/mkdocs_pandoc/pandoc_converter.py
@@ -74,7 +74,7 @@ class PandocConverter:
                 flattened.append(
                              {
                                 'file': page[0],
-                                'title': page[1],
+                                'title': '%s {.unnumbered}' % page[1],
                                 'level': level,
                              })
             if type(page) is dict:
@@ -82,7 +82,7 @@ class PandocConverter:
                     flattened.append(
                             {
                                 'file': list(page.values())[0],
-                                'title': list(page.keys())[0],
+                                'title': '%s {.unnumbered}' % list(page.keys())[0],
                                 'level': level,
                              })
                 if type(list(page.values())[0]) is list:
@@ -90,7 +90,7 @@ class PandocConverter:
                     flattened.append(
                             {
                                 'file': None,
-                                'title': list(page.keys())[0],
+                                'title': '%s {.unnumbered}' % list(page.keys())[0],
                                 'level': level,
                             })
                     # Add children sections


### PR DESCRIPTION
Allow mkdocs-pandoc to support structured pages. For example, the following pages structure 

``` yaml
pages:
  - Section 1: section-1.md
  - Section 2:
    - Section 2.1: section-2/section-2-1.md
    - Section 2.2: section-2/section-2-2.md
```

will become

> # Section 1
> 
> section-1.md content ...
> # Section 2
> # Section 2.1
> 
> section-2/section-2-1.md content
> # Section 2.2
> 
> section-2/section-2-2.md content
