### PR TITLE
patch for mkdocs version >1.0.4, where 'pages' is now 'nav'

### DIFF
--- a/mkdocs_pandoc/pandoc_converter.py
+++ b/mkdocs_pandoc/pandoc_converter.py
@@ -100,7 +100,7 @@ class PandocConverter:
         lines."""
         lines = []
 
-        pages = self.flatten_pages(self.config['pages'])
+        pages = self.flatten_pages(self.config['nav'])
 
         f_exclude = mkdocs_pandoc.filters.exclude.ExcludeFilter(
                 exclude=self.exclude)


### PR DESCRIPTION
patch for mkdocs version >1.0.4, where 'pages' is now 'nav' in mkdocs.yml file